### PR TITLE
Rescue when exception is thrown in check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.1.10-alpine
 
-RUN apk add --no-cache \ 
+RUN apk add --no-cache \
       bash \
       git \
       make \


### PR DESCRIPTION
Host is unreachable exception was killing the checks when the cluster doesn't have a master.  This will now just cause a failure rather than killing the script.
Also some whitespace kill included